### PR TITLE
Spellcheck fix but slightly different

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -52,4 +52,4 @@ planet "Sies Upi"
 	description "Sies Upi is one of the most recently colonized planets of the Gegno Vi. This hot, dry world with harsh living environments serves as more of an outpost than it does a colony, but nevertheless the Vi found ways to create manageable living conditions."
 		"Brocken"
 system Currus
-link Currus
+	link Currus

--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -7,7 +7,6 @@
 		"Gord"
 		"gard"
 		"Mata"
-		"Currus"
 		"Diamond Grey"
 		"Grey Wolf"
 				`	"The Grey Goose."`
@@ -52,3 +51,5 @@ system Nnaug
 planet "Sies Upi"
 	description "Sies Upi is one of the most recently colonized planets of the Gegno Vi. This hot, dry world with harsh living environments serves as more of an outpost than it does a colony, but nevertheless the Vi found ways to create manageable living conditions."
 		"Brocken"
+system Currus
+link Currus


### PR DESCRIPTION
Lets try this again. (All the instances it flagged either said "system Currus" or "link Currus" and since someone said you needed the entire line, I just put those two things. I think it should work now, maybe, since that is all those lines contained.)