### PR TITLE
A few more Incipias tweaks

### DIFF
--- a/data/governments.txt
+++ b/data/governments.txt
@@ -1569,7 +1569,7 @@ government "Sheragi"
 	"crew defense" 0
 
 government "Silent Ones"
-	"display name" "???"
+	"display name" "Indigenous Lifeform"
 	swizzle 0
 	"player reputation" 1
 	"bribe" 0

--- a/data/incipias/tace mesa.txt
+++ b/data/incipias/tace mesa.txt
@@ -86,20 +86,19 @@ mission "The Silent Ones"
 		government "Silent Ones"
 		personality harvests mining mute timid
 		system Il'le
-		ship "Tace Mesa"
+		ship "Tace Mesa" ""
 	npc save
 		government "Silent Ones"
 		personality harvests mining mute timid
 		system Il'le
-		ship "Tace Mesa"
+		ship "Tace Mesa" ""
 	npc save
 		government "Silent Ones"
 		personality harvests mining mute timid
 		system Il'le
-		ship "Tace Mesa"
+		ship "Tace Mesa" ""
 	npc save
 		government "Silent Ones"
 		personality harvests mining mute timid
 		system Il'le
-		ship "Tace Mesa" "???"
-
+		ship "Tace Mesa" ""

--- a/data/map systems.txt
+++ b/data/map systems.txt
@@ -9231,10 +9231,6 @@ system Currus
 		distance 393
 		period 311.636
 	object
-		sprite planet/forest0
-		distance 468
-		period 404.975
-	object
 		sprite planet/io-b
 		distance 543
 		period 506.127
@@ -9242,34 +9238,6 @@ system Currus
 		sprite planet/gas13-b
 		distance 999
 		period 1263.01
-
-system "Porta Terra"
-	pos 202.6 -825.506
-	attributes "bright star" "notable star"
-	arrival 3650
-	habitable 3650
-	belt 1291
-	link Hui'uc
-	asteroids "large metal" 1 2.611
-	object
-		sprite star/a0
-		period 10
-	object Aera
-		sprite planet/aera
-		distance 900
-		period 178.762
-		object
-			sprite planet/desert4
-			distance 300
-			period 188.115
-	object Igna
-		sprite planet/gas1-b
-		distance 1449
-		period 365.187
-		object
-			sprite planet/ice8
-			distance 504
-			period 427.707
 
 system "Da Ent"
 	pos -6.22391 -462.536
@@ -27131,6 +27099,34 @@ system Porrima
 			sprite planet/dust0
 			distance 294
 			period 11.4255
+
+system "Porta Terra"
+	pos 202.6 -825.506
+	attributes "bright star" "notable star"
+	arrival 3650
+	habitable 3650
+	belt 1291
+	link Hui'uc
+	asteroids "large metal" 1 2.611
+	object
+		sprite star/a0
+		period 10
+	object Aera
+		sprite planet/aera
+		distance 900
+		period 178.762
+		object
+			sprite planet/desert4
+			distance 300
+			period 188.115
+	object Igna
+		sprite planet/gas1-b
+		distance 1449
+		period 365.187
+		object
+			sprite planet/ice8
+			distance 504
+			period 427.707
 
 system Postverta
 	hidden


### PR DESCRIPTION
A few more things:

- Porta Terra was not in order, and I removed the forest landable that stood out (it was also overlapping 3 orbits)
- Gave the Tace Mesa "" for names, which makes them not have their name repeated (they now appear the same way Voidsprites do with no name, just "Void Sprite"
- Changed the display name for the The Silent Ones to "Indigenous Lifeform" (yet they don't share gov bonds with the action government. I feel like our scanners can go as far as to "guess" something is indigenous to the system, Like Voidsprites and the Iije; having "???" seems a bit odd. Either way, you can still later on change it to "The Silent Ones" if you end up getting information on it. If you like the "???", perhaps "Unknown" works instead.